### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -37,7 +37,7 @@ jobs:
           fi
           echo $matrix
           echo $matrix| jq .
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
         shell: bash
 
   master-build-packages:

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -120,7 +120,7 @@ jobs:
               fi
           fi
           echo "$TARGET"
-          echo ::set-output name=target::$TARGET
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
         env:
           DISTRO: ${{ matrix.distro }}
         shell: bash

--- a/.github/workflows/call-test-images.yaml
+++ b/.github/workflows/call-test-images.yaml
@@ -98,7 +98,7 @@ jobs:
         run: |
           docker pull --platform=${{ matrix.arch }} "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
           ACTUAL_ARCH=$(docker image inspect --format '{{.Architecture}}' "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG")
-          echo ::set-output name=ACTUAL_ARCH::$ACTUAL_ARCH
+          echo "ACTUAL_ARCH=$ACTUAL_ARCH" >> "$GITHUB_OUTPUT"
           docker image inspect "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
         shell: bash
         env:

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -44,7 +44,7 @@ jobs:
       run: |
         curl --fail -LO "$AWS_URL/latest-version.txt"
         VERSION=$(cat latest-version.txt)
-        echo ::set-output name=VERSION::$VERSION
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Run package installation tests

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -32,7 +32,7 @@ jobs:
       # For cron builds, i.e. nightly, we provide date and time as extra parameter to distinguish them.
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date '+%Y-%m-%d-%H_%M_%S')"
+        run: echo "date=$(date '+%Y-%m-%d-%H_%M_%S')" >> "$GITHUB_OUTPUT"
 
       - name: Debug event output
         uses: hmarr/debug-action@v2
@@ -70,7 +70,7 @@ jobs:
             echo "Unable to determine branch to use"
             exit 1
           fi
-          echo "::set-output name=branch::$cron_branch"
+          echo "branch=$cron_branch" >> "$GITHUB_OUTPUT"
         shell: bash
 
   unstable-build-images:

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -48,7 +48,7 @@ jobs:
               echo "Defaulting to master"
               VERSION=master
             fi
-            echo ::set-output name=VERSION::$VERSION
+            echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
         shell: bash
         env:
           # Use the dispatch variable in preference, if empty use the context ref_name which should


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter